### PR TITLE
Fix pr

### DIFF
--- a/.github/workflows/dbt-pr.yml
+++ b/.github/workflows/dbt-pr.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           jq 'del(.metadata) | del(.nodes[].metadata.schema) | del(.nodes[].metadata.database) | del(.nodes[].stats) | del(.nodes[].metadata.type) | del(.sources[].stats) | del(.sources[].metadata.database)' catalog.json > catalog-modified.json
           jq 'del(.metadata) | del(.nodes[].metadata.schema) | del(.nodes[].metadata.database) | del(.nodes[].stats) | del(.nodes[].metadata.type) | del(.sources[].stats) | del(.sources[].metadata.database)' target/catalog.json > target/catalog-modified.json
-          DIFF=$(npx json-diff catalog-modified.json target/catalog-modified.json)
+          DIFF=$(npx json-diff catalog-modified.json target/catalog-modified.json | head -c 61000)
           if [[ ${#DIFF} -gt 60000 ]] ; then
               DIFF="${DIFF::60000}"$'\n...\nDiff too long to be shown in full'
           fi


### PR DESCRIPTION
Cut output of json-diff before storing in env variable
This seems to be necessary to avoid crash for very large outputs.
We cut it to 61000 characters, before the diff is cut to 60000 characters later, with the "Diff not shown in full" message.