### PR TITLE
Use print instead of log

### DIFF
--- a/dbt/macros/docs.md
+++ b/dbt/macros/docs.md
@@ -39,10 +39,10 @@ When developing models, you can use `generate_model_yaml` to generate a model sc
 
 This will generate model schema for a model called `buffered_hendelser`:
 
-`dbt run-operation saga_dbt_public.generate_model_yaml --args '{"model_name": "buffered_hendelser"}'`
+`dbt -q run-operation saga_dbt_public.generate_model_yaml --args '{"model_name": "buffered_hendelser"}'`
 
 If you want to generate doc tags instead of inlining descriptions, useful if the same column description is used in multiple models:
-`dbt run-operation saga_dbt_public.generate_model_yaml --args '{"model_name": "buffered_hendelser", "docs": True}'`
+`dbt -q run-operation saga_dbt_public.generate_model_yaml --args '{"model_name": "buffered_hendelser", "docs": True}'`
 {% enddocs %}
 
 

--- a/dbt/macros/generate_model_yaml.sql
+++ b/dbt/macros/generate_model_yaml.sql
@@ -28,7 +28,7 @@
   {% endfor %}
   {% if execute %}
     {% set joined = model_yaml | join ('\n') %}
-    {{ log(joined, info=True) }}
+    {{ print(joined) }}
     {% do return(joined) %}
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This allows us to suppress all other output with the -q flag, so that the output can be directed directly to a YAML file #patch